### PR TITLE
Add support for next and errNext callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Methods available to the ```Request``` instance.
 
 * ```Request.prototype.beforeSend (fn)``` Allows the `req` or `res` objects to be dynamically modified before the response is sent. The provided function will be invoked in the context of the `Request` instance. See [example specs](https://github.com/TGOlson/dupertest/blob/master/examples/entities-controller_spec.js#L86) for usage.
 
+* ```Request.prototype.next (fn)``` Allows to test controllers (middleware) that are not supposed to sent a response to the client, but pass the control to the next middleware. See [example specs](https://github.com/TGOlson/dupertest/blob/next-callback/spec/request_spec.js#L81) for usage.
+
+* ```Request.prototype.errNext (fn)``` Same as `Request.prototype.next (fn)`, but this allows to test error handling middleware, when `next` is called with a parameter in the controller (`next(err)`). See [example specs](https://github.com/TGOlson/dupertest/blob/next-callback/spec/request_spec.js#L134) for usage.
+
 
 * ```Request.prototype.expect (object, fn)``` Shorthand syntax for a Jasmine expect statement. The expectation is often in the form of an object (but can be anything), and will be compared to the return value of the controller action with the Jasmine statement: ```expect(obj).toEqual(object)```. This method ends the request chain. As such, the callback function will often be ```done```. Note: Jasmine must be the test framework for this method to work.
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -29,6 +29,16 @@ Request.prototype.extendRes = function(data) {
   return this;
 };
 
+Request.prototype.next = function (callback) {
+  this.nextFn = callback;
+  return this;
+};
+
+Request.prototype.errNext = function (callback) {
+  this.errNextFn = callback;
+  return this;
+};
+
 Request.prototype.beforeSend = function(transformer) {
   this.transformer = transformer;
   return this;
@@ -43,16 +53,22 @@ Request.prototype.expect = function (expectation, callback) {
   this.end(assertion);
 };
 
-Request.prototype.end = function(callback) {
-  var action = this.action,
-      transformer = makeFunction(this.transformer);
+Request.prototype.end = function (callback) {
+  var _this = this,
+    action = this.action,
+    transformer = makeFunction(this.transformer),
+    next = function (err) {
+      if (err)
+        return makeFunction(_this.errNextFn)(err, _this.req, _this.res);
+      return makeFunction(_this.nextFn)(_this.req, _this.res);
+    };
 
-  if(!action) throw new Error('No action defined');
+  if (!action) throw new Error('No action defined');
 
   transformer.call(this);
 
   this.res.send = makeFunction(callback);
-  action(this.req, this.res);
+  action(this.req, this.res, next);
 };
 
 function makeFunction(fn) {

--- a/spec/request_spec.js
+++ b/spec/request_spec.js
@@ -78,6 +78,115 @@ describe('request', function() {
 		});
 	});
 
+	describe('next', function() {
+		it('should not fail the test if no nextFn was added', function() {
+			expect(function(){
+				request.end();
+			}).not.toThrow();
+		});
+
+		it('should add the next callback as a parameter', function() {
+			var fn = function(req, res) {};
+
+			request.next(fn);
+			expect(request.nextFn).not.toBeUndefined();
+		});
+
+		it('should send the nextFn as a parameter to the controller', function() {
+			var fn = function(req, res) {};
+
+			request.action = function (req, res, next) {
+				expect(next).not.toBeUndefined();
+			};
+			request.next(fn)
+				.end();
+		});
+
+		it('should call the nextFn if next callback is called in the controller', function() {
+			var wrapper = {
+				fn: function(req, res) {}
+			};
+
+			spyOn(wrapper, 'fn');
+
+			request.action = function (req, res, next) {
+				next();
+			};
+			request.next(wrapper.fn)
+				.end(function(){
+					expect(wrapper.fn).toHaveBeenCalled();
+				});
+		});
+
+		it('should call the nextFn with req, res parameters', function() {
+			request.action = function (req, res, next) {
+				next();
+			};
+			request.next(function(req, res) {
+				expect(req).not.toBeUndefined();
+				expect(res).not.toBeUndefined();
+				expect(req).toBe(request.req);
+				expect(res).toBe(request.res);
+			}).end();
+		});
+	});
+
+	describe('errNext', function() {
+		it('should not fail the test if no errNextFn was added', function() {
+			expect(function(){
+				request.end();
+			}).not.toThrow();
+		});
+
+		it('should add the errNextFn callback as a parameter', function() {
+			var fn = function(err, req, res) {};
+
+			request.errNext(fn);
+			expect(request.errNextFn).not.toBeUndefined();
+		});
+
+		it('should send the errNextFn as a parameter to the controller', function() {
+			var fn = function(req, res) {};
+
+			request.action = function (req, res, next) {
+				expect(next).not.toBeUndefined();
+			};
+			request.errNext(fn)
+			.end();
+		});
+
+		it('should call the errNextFn if next callback is called in the controller with a parameter',
+			function() {
+				var wrapper = {
+					fn: function(err, req, res) {}
+				};
+
+				spyOn(wrapper, 'fn');
+
+				request.action = function (req, res, next) {
+					next(new Error('Test callback'));
+				};
+				request.errNext(wrapper.fn)
+				.end(function(){
+					expect(wrapper.fn).toHaveBeenCalled();
+				});
+		});
+
+		it('should call the errNextFn with err, req, res parameters', function() {
+			request.action = function (req, res, next) {
+				next(new Error('Test callback'));
+			};
+			request.errNext(function(err, req, res) {
+				expect(err).not.toBeUndefined();
+				expect(req).not.toBeUndefined();
+				expect(res).not.toBeUndefined();
+				expect(req).toBe(request.req);
+				expect(res).toBe(request.res);
+			}).end();
+		});
+	});
+
+
 	describe('beforeSend', function() {
 		it('should set a transformer property on the request', function() {
 			function transformer() {}


### PR DESCRIPTION
Fix #3 : Add support for testing middleware that passes the control to the next middleware.

*Sorry for the formatting updates. I was in a hurry and lazy to disable all the formatting tools.*