### PR TITLE
Ability to set swagger-express-mw parameters

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -9,6 +9,11 @@ Request.prototype.params = function(params) {
   return this;
 };
 
+Request.prototype.swagger = function(params) {
+  this.req.swagger = params;
+  return this;
+};
+
 Request.prototype.query = function(query) {
   this.req.query = query;
   return this;

--- a/spec/request_spec.js
+++ b/spec/request_spec.js
@@ -46,6 +46,15 @@ describe('request', function() {
 			expect(request.req.body).toEqual(body);
 		});
 	});
+	
+	describe('swagger', function() {
+		it('should set the swagger property of a request', function() {
+			var params = {id: 123};
+
+			request.swagger(params);
+			expect(request.req.swagger).toEqual(params);
+		});
+	});
 
 	describe('headers', function() {
 		it('should set the headers property of a request', function() {


### PR DESCRIPTION
swagger-express-mw places the parameters of a request under the swagger property.
This change allows to use dupertest for testing of requests normally routed by swagger-express-mw.