### PR TITLE
Updates to support override of send while retaining existing behavior…

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -72,7 +72,13 @@ Request.prototype.end = function (callback) {
 
   transformer.call(this);
 
-  this.res.send = makeFunction(callback);
+  var sendOverride = makeFunction(this.res.send);
+  var sendDefault = makeFunction(callback);
+  this.res.send = function() {
+    sendOverride.apply(this.res, arguments);
+    return sendDefault.apply(this.res, arguments);
+  }.bind(this);
+
   action(this.req, this.res, next);
 };
 

--- a/spec/request_spec.js
+++ b/spec/request_spec.js
@@ -76,6 +76,20 @@ describe('request', function() {
 			request.extendRes(data);
 			expect(request.res.additionalFn).toBe(data.additionalFn);
 		});
+		it('should safely extend the send', function () {
+			var expectedResponse = {};
+			var data = {
+				send: function() {}
+			};
+
+			spyOn(data, 'send');
+			new Request(function (req, res, next) {
+				res.send(expectedResponse);
+			}).extendRes(data).end(function (res) {
+				expect(data.send).toHaveBeenCalled();
+				expect(res).toEqual(expectedResponse);
+			});
+		});
 	});
 
 	describe('next', function() {
@@ -243,12 +257,15 @@ describe('request', function() {
 		});
 	});
 
-	describe('end', function() {
-		it('should set res.send to the provided callback', function() {
-			function callback() {}
+	describe('end', function () {
+		it('should call the provided callback', function () {
+			var wrapper = {
+				fn: function(err, req, res) {}
+			};
 
-			request.end(callback);
-			expect(request.res.send).toEqual(callback);
+			spyOn(wrapper, 'fn');
+			request.end(wrapper.fn);
+			expect(wrapper.fn).toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
… to pass through object into response. As discussed in #11... allows override of send which otherwise gets squashed in `request.end()`.